### PR TITLE
Adding quaternion to yaw, pitch, roll control angles math

### DIFF
--- a/firmware/debug/teapot.py
+++ b/firmware/debug/teapot.py
@@ -1,4 +1,6 @@
 """
+Utility to represent the orientation of the IMU in 3D using Pygame and PyOpenGL.
+Find the repository here: https://github.com/thecountoftuscany/PyTeapot-Quaternion-Euler-cube-rotation
 PyTeapot module for drawing rotating cube using OpenGL as per
 quaternion or yaw, pitch, roll angles received over serial port.
 """

--- a/firmware/debug/teapot.py
+++ b/firmware/debug/teapot.py
@@ -1,0 +1,213 @@
+"""
+PyTeapot module for drawing rotating cube using OpenGL as per
+quaternion or yaw, pitch, roll angles received over serial port.
+"""
+
+import pygame
+import math
+from OpenGL.GL import *
+from OpenGL.GLU import *
+from pygame.locals import *
+
+useSerial = True # set true for using serial for data transmission, false for wifi
+useQuat = True   # set true for using quaternions, false for using y,p,r angles
+
+if(useSerial):
+    import serial
+    ser = serial.Serial('/dev/tty.usbmodem1101', 38400)
+else:
+    import socket
+
+    UDP_IP = "0.0.0.0"
+    UDP_PORT = 5005
+    sock = socket.socket(socket.AF_INET, # Internet
+                         socket.SOCK_DGRAM) # UDP
+    sock.bind((UDP_IP, UDP_PORT))
+
+def main():
+    video_flags = OPENGL | DOUBLEBUF
+    pygame.init()
+    screen = pygame.display.set_mode((640, 480), video_flags)
+    pygame.display.set_caption("PyTeapot IMU orientation visualization")
+    resizewin(640, 480)
+    init()
+    frames = 0
+    ticks = pygame.time.get_ticks()
+    while 1:
+        event = pygame.event.poll()
+        if event.type == QUIT or (event.type == KEYDOWN and event.key == K_ESCAPE):
+            break
+        if(useQuat):
+            [w, nx, ny, nz] = read_data()
+        else:
+            [yaw, pitch, roll] = read_data()
+        if(useQuat):
+            draw(w, nx, ny, nz)
+        else:
+            draw(1, yaw, pitch, roll)
+        pygame.display.flip()
+        frames += 1
+    print("fps: %d" % ((frames*1000)/(pygame.time.get_ticks()-ticks)))
+    if(useSerial):
+        ser.close()
+
+
+def resizewin(width, height):
+    """
+    For resizing window
+    """
+    if height == 0:
+        height = 1
+    glViewport(0, 0, width, height)
+    glMatrixMode(GL_PROJECTION)
+    glLoadIdentity()
+    gluPerspective(45, 1.0*width/height, 0.1, 100.0)
+    glMatrixMode(GL_MODELVIEW)
+    glLoadIdentity()
+
+
+def init():
+    glShadeModel(GL_SMOOTH)
+    glClearColor(0.0, 0.0, 0.0, 0.0)
+    glClearDepth(1.0)
+    glEnable(GL_DEPTH_TEST)
+    glDepthFunc(GL_LEQUAL)
+    glHint(GL_PERSPECTIVE_CORRECTION_HINT, GL_NICEST)
+
+
+def cleanSerialBegin():
+    if(useQuat):
+        try:
+            line = ser.readline().decode('UTF-8').replace('\n', '')
+            w = float(line.split('w')[1])
+            nx = float(line.split('a')[1])
+            ny = float(line.split('b')[1])
+            nz = float(line.split('c')[1])
+        except Exception:
+            pass
+    else:
+        try:
+            line = ser.readline().decode('UTF-8').replace('\n', '')
+            yaw = float(line.split('y')[1])
+            pitch = float(line.split('p')[1])
+            roll = float(line.split('r')[1])
+        except Exception:
+            pass
+
+
+def read_data():
+    if(useSerial):
+        ser.reset_input_buffer()
+        cleanSerialBegin()
+        line = ser.readline().decode('UTF-8').replace('\n', '')
+        print(line)
+    else:
+        # Waiting for data from udp port 5005
+        data, addr = sock.recvfrom(1024) # buffer size is 1024 bytes
+        line = data.decode('UTF-8').replace('\n', '')
+        print(line)
+                
+    if(useQuat):
+        try:
+            w = float(line.split('w')[1])
+            nx = float(line.split('a')[1])
+            ny = float(line.split('b')[1])
+            nz = float(line.split('c')[1])
+            return [w, nx, ny, nz]
+        except:
+            return [1, 0, 0, 0]
+    else:
+        yaw = float(line.split('y')[1])
+        pitch = float(line.split('p')[1])
+        roll = float(line.split('r')[1])
+        return [yaw, pitch, roll]
+
+
+def draw(w, nx, ny, nz):
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT)
+    glLoadIdentity()
+    glTranslatef(0, 0.0, -7.0)
+
+    drawText((-2.6, 1.8, 2), "PyTeapot", 18)
+    drawText((-2.6, 1.6, 2), "Module to visualize quaternion or Euler angles data", 16)
+    drawText((-2.6, -2, 2), "Press Escape to exit.", 16)
+
+    if(useQuat):
+        [yaw, pitch , roll] = quat_to_ypr([w, nx, ny, nz])
+        w = max(min(w, 1.0), -1.0)
+        angle = 2 * math.acos(w) * 180.00 / math.pi
+        drawText((-2.6, -1.8, 2), "Yaw: %f, Pitch: %f, Roll: %f" %(yaw, pitch, roll), 16)
+        glRotatef(angle, -1 * nx, nz, ny)
+    else:
+        yaw = nx
+        pitch = ny
+        roll = nz
+        drawText((-2.6, -1.8, 2), "Yaw: %f, Pitch: %f, Roll: %f" %(yaw, pitch, roll), 16)
+        glRotatef(-roll, 0.00, 0.00, 1.00)
+        glRotatef(pitch, 1.00, 0.00, 0.00)
+        glRotatef(yaw, 0.00, 1.00, 0.00)
+
+    glBegin(GL_QUADS)
+    glColor3f(0.0, 1.0, 0.0)
+    glVertex3f(1.0, 0.2, -1.0)
+    glVertex3f(-1.0, 0.2, -1.0)
+    glVertex3f(-1.0, 0.2, 1.0)
+    glVertex3f(1.0, 0.2, 1.0)
+
+    glColor3f(1.0, 0.5, 0.0)
+    glVertex3f(1.0, -0.2, 1.0)
+    glVertex3f(-1.0, -0.2, 1.0)
+    glVertex3f(-1.0, -0.2, -1.0)
+    glVertex3f(1.0, -0.2, -1.0)
+
+    glColor3f(1.0, 0.0, 0.0)
+    glVertex3f(1.0, 0.2, 1.0)
+    glVertex3f(-1.0, 0.2, 1.0)
+    glVertex3f(-1.0, -0.2, 1.0)
+    glVertex3f(1.0, -0.2, 1.0)
+
+    glColor3f(1.0, 1.0, 0.0)
+    glVertex3f(1.0, -0.2, -1.0)
+    glVertex3f(-1.0, -0.2, -1.0)
+    glVertex3f(-1.0, 0.2, -1.0)
+    glVertex3f(1.0, 0.2, -1.0)
+
+    glColor3f(0.0, 0.0, 1.0)
+    glVertex3f(-1.0, 0.2, 1.0)
+    glVertex3f(-1.0, 0.2, -1.0)
+    glVertex3f(-1.0, -0.2, -1.0)
+    glVertex3f(-1.0, -0.2, 1.0)
+
+    glColor3f(1.0, 0.0, 1.0)
+    glVertex3f(1.0, 0.2, -1.0)
+    glVertex3f(1.0, 0.2, 1.0)
+    glVertex3f(1.0, -0.2, 1.0)
+    glVertex3f(1.0, -0.2, -1.0)
+    glEnd()
+
+
+def drawText(position, textString, size):
+    font = pygame.font.SysFont("Courier", size, True)
+    textSurface = font.render(textString, True, (255, 255, 255, 255), (0, 0, 0, 255))
+    textData = pygame.image.tostring(textSurface, "RGBA", True)
+    glRasterPos3d(*position)
+    glDrawPixels(textSurface.get_width(), textSurface.get_height(), GL_RGBA, GL_UNSIGNED_BYTE, textData)
+
+def normalize_quaternion(q):
+    norm = math.sqrt(sum(x * x for x in q))
+    return [x / norm for x in q]
+
+def quat_to_ypr(q):
+    q = normalize_quaternion(q)  # Normalize the quaternion first
+    yaw   = math.atan2(2.0 * (q[1] * q[2] + q[0] * q[3]), q[0] * q[0] + q[1] * q[1] - q[2] * q[2] - q[3] * q[3])
+    pitch = -math.asin(2.0 * (q[1] * q[3] - q[0] * q[2]))
+    roll  = math.atan2(2.0 * (q[0] * q[1] + q[2] * q[3]), q[0] * q[0] - q[1] * q[1] - q[2] * q[2] + q[3] * q[3])
+    pitch *= 180.0 / math.pi
+    yaw   *= 180.0 / math.pi
+    yaw   -= -0.13  # Declination at Chandrapur, Maharashtra is - 0 degress 13 min
+    roll  *= 180.0 / math.pi
+    return [yaw, pitch, roll]
+
+
+if __name__ == '__main__':
+    main()

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -106,6 +106,11 @@ void quaternionToEulerGI(sh2_GyroIntegratedRV_t *rotational_vector, euler_t *ypr
 }
 
 void quaternionToControlAngles(sh2_Quaternion_t *quaternion, euler_t *ypr)
+/*
+The extraction of the YPR angles does not correspond to any of the standard Euler angles sequences.
+The reason for this is to provide the best possible feeling to the pilot, preventing the hand from
+tilting too far in the corners and ensuring symmetry for the pitch and roll angles.
+*/
 {
 	// ypr->pitch = atan2((2 * (quaternion->x * quaternion->y + quaternion->w * quaternion->z)), (quaternion->w*quaternion->w + quaternion->x*quaternion->x - quaternion->y*quaternion->y - quaternion->z*quaternion->z));
 	// ypr->roll = atan2((- 2 * (quaternion->x * quaternion->z - quaternion->w * quaternion->y)), (quaternion->w*quaternion->w + quaternion->x*quaternion->x - quaternion->y*quaternion->y - quaternion->z*quaternion->z));
@@ -117,6 +122,7 @@ void quaternionToControlAngles(sh2_Quaternion_t *quaternion, euler_t *ypr)
     //yaw rotation around x
     //pitch rotation around z
     //roll rotation around y
+	// The quaternion order and sign has to be changed to ensure that the YPR values are correct
     float q0 = quaternion->w; //w
     float q1 = quaternion->z; //x
     float q2 = - quaternion->x; //y
@@ -215,14 +221,6 @@ void loop()
 		Serial.print("c");
 		Serial.print(q3);
 		Serial.println("c");
-		// Serial.print("yaw: ");
-		// Serial.print(ypr.yaw);
-		// Serial.print("\t");
-		// Serial.print("pitch: ");
-		// Serial.print(ypr.pitch);
-		// Serial.print("\t");
-		// Serial.print("roll: ");
-		// Serial.println(ypr.roll);
 
 		int buttonState_1 = digitalRead(2);
 
@@ -230,7 +228,6 @@ void loop()
 			prevButtonState_1 = buttonState_1;
 			sh2_Quaternion_t myQuaternion = {0, 0, q1, q0};
 			sh2_setReorientation(&myQuaternion);
-			//Serial.println("hello");
 		}
 		else {
 			prevButtonState_1 = buttonState_1;
@@ -242,7 +239,6 @@ void loop()
 			prevButtonState_2 = buttonState_2;
 			sh2_Quaternion_t myQuaternion = {0, 0, 0, 1};
 			sh2_setReorientation(&myQuaternion);
-			//Serial.println("hello");
 		}
 		else {
 			prevButtonState_2 = buttonState_2;


### PR DESCRIPTION
The sensor fusion should produce a quaternion representing the attitude of the controller. From there, we should be able to reset the quaternion's position to zero once we arm the controller. The yaw, pitch and roll angles should be extracted from the quaternion and sent over to the transceiver.