### PR TITLE
platformio: force FastLED to exactly version 3.6

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,20 +19,20 @@ board = pico
 framework = arduino
 monitor_dtr = 1
 monitor_speed = 115200
-monitor_filters = 
+monitor_filters =
 	send_on_enter
 	colorize
 platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board_build.core = earlephilhower
 board_build.filesystem_size = 0.5m
-platform_packages = 
+platform_packages =
 	maxgerhardt/framework-arduinopico@https://github.com/earlephilhower/arduino-pico.git#master
 
 [env:debug]
-lib_deps = 
+lib_deps =
 	adafruit/Adafruit LIS3MDL @ ^1.2.4
 	adafruit/Adafruit MPU6050@^2.2.6
 	adafruit/Adafruit Unified Sensor@^1.1.4
 	aster94/SensorFusion@^1.0.6
 	adafruit/Adafruit DRV2605 Library@^1.2.4
-	fastled/FastLED@^3.6.0
+	fastled/FastLED@3.6.0


### PR DESCRIPTION
### Problem
As discussed on Discord in https://discordapp.com/channels/1022538123915300865/1213646719695192084/1246141881222561912 and the following messages and thread there is an issue with the FastLED library version 3.7 incompatibility which produces `Error: invalid offset, value too big` compile errors.

See https://github.com/earlephilhower/arduino-pico/discussions/1649

### Solution
I suggest forcing the version we use to FastLED 3.6 which has also worked so far. I'd look into updating the version with a fix or alternatives later since I'm only getting started and would like to start from a state that builds and has the functionality of when I received the controller.