### PR TITLE
Add firmware readme with Windows & Mac setup instructions

### DIFF
--- a/firmware/README.md
+++ b/firmware/README.md
@@ -1,0 +1,14 @@
+# Setup instructions
+
+## Windows
+
+1. Install git by running the following command in a terminal winow: `winget install Git.Git`
+2. [Enable long paths both on the operating system and git level](https://arduino-pico.readthedocs.io/en/latest/platformio.html#important-steps-for-windows-users-before-installing) 
+3. Install [Visual Studio Code](https://code.visualstudio.com/)
+4. Install [PlatformIO IDE Extension](https://platformio.org/install/ide?install=vscode)
+5. Clone the repository e.g. using `git clone https://github.com/atopile/swoop.git`
+6. Open the repository in Visual Studio Code e.g. by entering the directory `cd swoop` and running the command `code .`
+7. Let PlatformIO install all dependencies and reopen the IDE window when asked to
+8. Donwload [Zadig](https://zadig.akeo.ie/) and install the WinUSB driver for the connected "RP2 Boot" device when Swoop is connected over USB
+![Zadig window](https://forums.raspberrypi.com/download/file.php?id=55573&sid=6964c0e56687c9a6d2d03afeaecb83e3 "Installing WinUSB using Zadig")
+9. Build and upload Swoop firmware using the small arrow button in the bottom right of Visual Studio Code

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -3,12 +3,20 @@
 ## Windows
 
 1. Install git by running the following command in a terminal winow: `winget install Git.Git`
-2. [Enable long paths both on the operating system and git level](https://arduino-pico.readthedocs.io/en/latest/platformio.html#important-steps-for-windows-users-before-installing) 
-3. Install [Visual Studio Code](https://code.visualstudio.com/)
-4. Install [PlatformIO IDE Extension](https://platformio.org/install/ide?install=vscode)
-5. Clone the repository e.g. using `git clone https://github.com/atopile/swoop.git`
-6. Open the repository in Visual Studio Code e.g. by entering the directory `cd swoop` and running the command `code .`
-7. Let PlatformIO install all dependencies and reopen the IDE window when asked to
-8. Donwload [Zadig](https://zadig.akeo.ie/) and install the WinUSB driver for the connected "RP2 Boot" device when Swoop is connected over USB
+1. [Enable long paths both on the operating system and git level](https://arduino-pico.readthedocs.io/en/latest/platformio.html#important-steps-for-windows-users-before-installing)
+1. Clone the repository e.g. using `git clone https://github.com/atopile/swoop.git`
+1. Install [Visual Studio Code](https://code.visualstudio.com/)
+1. Install [PlatformIO IDE Extension](https://platformio.org/install/ide?install=vscode)
+1. Reopen Visual Studio Code and open the folder of the repository, it will install all dependencies
+1. Donwload [Zadig](https://zadig.akeo.ie/) and install the WinUSB driver for the connected "RP2 Boot" device when Swoop is connected over USB
 ![Zadig window](https://forums.raspberrypi.com/download/file.php?id=55573&sid=6964c0e56687c9a6d2d03afeaecb83e3 "Installing WinUSB using Zadig")
-9. Build and upload Swoop firmware using the small arrow button in the bottom right of Visual Studio Code
+1. At the bottom left of the window you find buttons for building, uploading, serial telemetry
+
+## Mac
+
+1. Install git e.g. via [Homebrew](https://brew.sh/) using `brew install git` ([formula](https://formulae.brew.sh/formula/git))
+1. Clone Repository ´git clone https://github.com/atopile/swoop.git´
+1. Install [Visual Studio Code](https://code.visualstudio.com/) Hombrew command: `brew install --cask visual-studio-code` ([formula](https://formulae.brew.sh/cask/visual-studio-code))
+1. Install [PlatformIO Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide)
+1. Reopen Visual Studio Code and open the folder of the repository, it will install all dependencies
+1. At the bottom left of the window you find buttons for building, uploading, serial telemetry


### PR DESCRIPTION
Yesterday I installed the entire toolchain on my main Windows computer. In my last stab at firmware development, I used the Macbook. It took a bit longer because of some issues that I had to go through which seem to be very common but the documentation is not super easy to find. So I decided to make a small step by step guide for the next one going through the same process. ~I also had such a guide for Mac but can't find it at the moment. If I find it I'll extend.~